### PR TITLE
added set constraint decomposition for subseteq

### DIFF
--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1065,7 +1065,7 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
 
   //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
   // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
-  if(f.is_binary() && f.sig() == SUBSETEQ && f.seq(0).is(F::S) && f.seq(1).is(F::S)) {
+  if(f.is_binary() && f.sig() == SUBSETEQ) {
     auto left = f.seq(0).lv().data();
     auto right = f.seq(1).lv().data();
 
@@ -1074,19 +1074,19 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
       typename F::Sequence conjunction(alloc);
       auto booleanVars = set2bool_vars[left];
       for (auto& boolVar : booleanVars) {
+        auto rightBoolVar = boolVar;
         size_t pos = boolVar.find_last_of('_'); 
         long long int z = std::stoi(boolVar.substr(pos + 1));
         conjunction.push_back(
           F::make_binary(
             F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar)), EQ, F::make_bool(true, f.type()),f.type()),
             IMPLY,
-            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar.replace(boolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(rightBoolVar.replace(rightBoolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
           )
         );
       }
       return F::make_nary(AND, std::move(conjunction), f.type());
     }
-
   }
   return f;
 }

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1062,6 +1062,32 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
     }
     return F::make_nary(AND, std::move(conjunction), f.type());
   }
+
+  //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
+  // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
+  if(f.is_binary() && f.sig() == SUBSETEQ && f.seq(0).is(F::S) && f.seq(1).is(F::S)) {
+    auto left = f.seq(0).lv().data();
+    auto right = f.seq(1).lv().data();
+
+    if (!set2bool_vars[left].empty()) {
+      typename F::allocator_type alloc;
+      typename F::Sequence conjunction(alloc);
+      auto booleanVars = set2bool_vars[left];
+      for (auto& boolVar : booleanVars) {
+        size_t pos = boolVar.find_last_of('_'); 
+        long long int z = std::stoi(boolVar.substr(pos + 1));
+        conjunction.push_back(
+          F::make_binary(
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar)), EQ, F::make_bool(true, f.type()),f.type()),
+            IMPLY,
+            F::make_binary(F::make_lvar(f.type(), LVar<typename F::allocator_type>(boolVar.replace(boolVar.find(left), std::string(left).size(), right))), EQ, F::make_bool(true, f.type()),f.type())
+          )
+        );
+      }
+      return F::make_nary(AND, std::move(conjunction), f.type());
+    }
+
+  }
   return f;
 }
 

--- a/include/lala/logic/algorithm.hpp
+++ b/include/lala/logic/algorithm.hpp
@@ -1062,9 +1062,8 @@ std::optional<F> decompose_set_constraints(const F& f, std::map<std::string, std
     }
     return F::make_nary(AND, std::move(conjunction), f.type());
   }
-
-  //TODO check using implications S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables
-  // __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true
+  
+  // decompose subeq
   if(f.is_binary() && f.sig() == SUBSETEQ) {
     auto left = f.seq(0).lv().data();
     auto right = f.seq(1).lv().data();

--- a/tests/src/algorithm_test.cpp
+++ b/tests/src/algorithm_test.cpp
@@ -54,6 +54,22 @@ TEST(AST, SetRewritingDomain3) {
   );
 }
 
+TEST(AST, SetRewritingSubseteq) {
+  test_rewriting(
+    "var set of {1, 2}: S;\
+     var set of {1, 2, 3}: T;\
+     constraint set_subset(S, T);",
+
+    "var bool: __S_contains_1;\
+     var bool: __S_contains_2;\
+     var bool: __T_contains_1;\
+     var bool: __T_contains_2;\
+     var bool: __T_contains_3;\
+     constraint bool_imply(bool_eq(__S_contains_1, true), bool_eq(__T_contains_1, true));\
+     constraint bool_imply(bool_eq(__S_contains_2, true), bool_eq(__T_contains_2, true));"
+  );
+}
+
 TEST(AST, SetRewritingMembership1) {
   test_rewriting(
     "var int: x;\


### PR DESCRIPTION
S \subeq T where S and T are both sets S = {1, 2} and T = {1, 2, 3}. Both S and T have already been decomposed to set variables. Checking using implications gives:

 __S_contains__1 = true => __T_contains_1 = true AND __S_contains_2 = true => __T_contains_2 = true